### PR TITLE
fixing agent device update

### DIFF
--- a/src/ProdControlAV.API/Controllers/AgentsController.cs
+++ b/src/ProdControlAV.API/Controllers/AgentsController.cs
@@ -7,6 +7,7 @@ using ProdControlAV.API.Models;
 using ProdControlAV.API.Services;
 using ProdControlAV.Core.Models;
 using ProdControlAV.Core.Interfaces;
+using ProdControlAV.Infrastructure.Services;
 using static Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults;
 
 namespace ProdControlAV.API.Controllers;
@@ -21,19 +22,25 @@ public sealed class AgentsController : ControllerBase
     private readonly IJwtService _jwtService;
     private readonly ILogger<AgentsController> _logger;
     private readonly IAgentCommandQueueService _queueService;
+    private readonly IDeviceStatusStore _statusStore;
+    private readonly IDeviceStore _deviceStore;
     
     public AgentsController(
         AppDbContext db, 
         IAgentAuth auth, 
         IJwtService jwtService, 
         ILogger<AgentsController> logger,
-        IAgentCommandQueueService queueService) 
+        IAgentCommandQueueService queueService,
+        IDeviceStatusStore statusStore,
+        IDeviceStore deviceStore) 
     { 
         _db = db; 
         _auth = auth;
         _jwtService = jwtService;
         _logger = logger;
         _queueService = queueService;
+        _statusStore = statusStore;
+        _deviceStore = deviceStore;
     }
 
     private string? GetAgentIdFromClaims()
@@ -197,43 +204,24 @@ public sealed class AgentsController : ControllerBase
             var now = DateTime.UtcNow;
             var saved = 0;
 
+            // Save status to Azure Table Storage for device status and update the Devices table projection
             foreach (var r in req.Readings)
             {
-                // Determine device name and IP from DB when possible
-                string deviceName = r.DeviceId ?? "";
-                string ip = string.Empty;
-
                 if (Guid.TryParse(r.DeviceId, out var deviceGuid))
                 {
-                    var device = await _db.Devices.FirstOrDefaultAsync(d => d.Id == deviceGuid, ct);
-                    if (device != null)
+                    var statusString = r.IsOnline ? "ONLINE" : "OFFLINE";
+                    try
                     {
-                        deviceName = string.IsNullOrWhiteSpace(device.Name) ? device.Id.ToString() : device.Name;
-                        ip = device.Ip ?? string.Empty;
-                        
-                        device.Status = r.IsOnline; // update the device table with the latest status
+                        await _statusStore.UpsertAsync(tenantId, deviceGuid, statusString, r.LatencyMs, DateTimeOffset.UtcNow, ct);
+                        await _deviceStore.UpsertStatusAsync(tenantId, deviceGuid, statusString, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, ct);
                     }
-
-                    await _db.SaveChangesAsync(ct);
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "[STATUS] Failed projecting status to table storage for TenantId={TenantId} DeviceId={DeviceId}", tenantId, deviceGuid);
+                    }
                 }
-
-                var lastPingMs = r.LatencyMs.HasValue ? (long)r.LatencyMs.Value : 0L;
-
-                var statusLog = new DeviceStatusLog
-                {
-                    Id = Guid.NewGuid(),
-                    DeviceName = deviceName ?? string.Empty,
-                    IP = ip ?? string.Empty,
-                    IsOnline = r.IsOnline,
-                    LastPingMs = lastPingMs,
-                    Timestamp = now
-                };
-                
-                _db.DeviceStatusLogs.Add(statusLog);
-                saved++;
             }
-
-            await _db.SaveChangesAsync(ct);
+            
             _logger.LogInformation("[STATUS] Saved {Count} status readings for TenantId={TenantId}", saved, tenantId);
             return Ok(new { ok = true, saved });
         }

--- a/src/ProdControlAV.API/Program.cs
+++ b/src/ProdControlAV.API/Program.cs
@@ -173,14 +173,37 @@ builder.Services.AddSingleton<TableServiceClient>(sp => {
 // TableClient for DeviceStatus
 builder.Services.AddSingleton<TableClient>(sp => {
     var svc = sp.GetRequiredService<TableServiceClient>();
-    return svc.GetTableClient("DeviceStatus");
+    var client = svc.GetTableClient("DeviceStatus");
+    // Ensure the table exists at startup so projections don't fail later
+    try {
+        client.CreateIfNotExists();
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("TableSetup");
+        logger.LogInformation("Ensured Azure Table exists: DeviceStatus");
+    } catch (Exception ex) {
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("TableSetup");
+        logger.LogWarning(ex, "Failed to ensure Azure Table exists: DeviceStatus");
+    }
+    return client;
 });
 builder.Services.AddScoped<IDeviceStatusStore, TableDeviceStatusStore>();
 
 // TableClient for Devices (named registration)
 builder.Services.AddSingleton(sp => {
     var svc = sp.GetRequiredService<TableServiceClient>();
-    return svc.GetTableClient("Devices");
+    var client = svc.GetTableClient("Devices");
+    try {
+        client.CreateIfNotExists();
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("TableSetup");
+        logger.LogInformation("Ensured Azure Table exists: Devices");
+    } catch (Exception ex) {
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("TableSetup");
+        logger.LogWarning(ex, "Failed to ensure Azure Table exists: Devices");
+    }
+    return client;
 });
 builder.Services.AddScoped<IDeviceStore>(sp => {
     var tableClient = sp.GetRequiredService<TableServiceClient>().GetTableClient("Devices");

--- a/src/ProdControlAV.Agent/Services/AgentService.cs
+++ b/src/ProdControlAV.Agent/Services/AgentService.cs
@@ -112,43 +112,62 @@ public sealed class AgentService : BackgroundService
             _logger.LogInformation("Starting device ping cycle for {Count} of {Total} devices", devicesToPing.Count, deviceList.Count);
 
             var tasks = new List<Task>(devicesToPing.Count);
+            // capture state snapshot of ChangedAt before pinging so we can detect which devices changed during this cycle
+            var beforeChangedAt = new Dictionary<string, DateTimeOffset>();
             foreach (var d in devicesToPing)
             {
-                await _gate.WaitAsync(ct);
-                var delay = rnd.Next(0, 200);
-                tasks.Add(Task.Run(async () =>
-                {
-                    try
-                    {
-                        await Task.Delay(delay, ct);
-                        
-                        // Update last ping time before pinging
-                        if (_state.TryGetValue(d.Id, out var state))
-                        {
-                            state.LastPingAt = DateTimeOffset.UtcNow;
-                        }
-                        
-                        var up = d.PreferTcp && _opt.TcpFallbackPort is int p
-                            ? await TcpProbeAsync(d.Ip, p, _opt.PingTimeoutMs, ct)
-                            : await IcmpProbeAsync(d.Ip, _opt.PingTimeoutMs, ct);
-
-                        _logger.LogDebug("Ping result for {Name} ({Ip}): {Status}", d.Name, d.Ip, up ? "UP" : "DOWN");
-                        await UpdateStateAndPublishIfChanged(d, up, ct);
-                    }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
-                    {
-                        _logger.LogWarning(ex, "Probe error for {Name} ({Ip}): {Error}", d.Name, d.Ip, ex.Message);
-                        await UpdateStateAndPublishIfChanged(d, up: false, ct);
-                    }
-                    finally
-                    {
-                        _gate.Release();
-                    }
-                }, ct));
+                if (_state.TryGetValue(d.Id, out var st)) beforeChangedAt[d.Id] = st.ChangedAt;
+                else beforeChangedAt[d.Id] = DateTimeOffset.MinValue;
             }
+             foreach (var d in devicesToPing)
+             {
+                 await _gate.WaitAsync(ct);
+                 var delay = rnd.Next(0, 200);
+                 tasks.Add(Task.Run(async () =>
+                 {
+                     try
+                     {
+                         await Task.Delay(delay, ct);
+                         
+                         // Update last ping time before pinging
+                         if (_state.TryGetValue(d.Id, out var state))
+                         {
+                             state.LastPingAt = DateTimeOffset.UtcNow;
+                         }
+                         
+                         var up = d.PreferTcp && _opt.TcpFallbackPort is int p
+                             ? await TcpProbeAsync(d.Ip, p, _opt.PingTimeoutMs, ct)
+                             : await IcmpProbeAsync(d.Ip, _opt.PingTimeoutMs, ct);
 
-            await Task.WhenAll(tasks);
-            _logger.LogDebug("Completed device ping cycle for {Count} devices", devicesToPing.Count);
+                         _logger.LogDebug("Ping result for {Name} ({Ip}): {Status}", d.Name, d.Ip, up ? "UP" : "DOWN");
+                         await UpdateStateAndPublishIfChanged(d, up, ct);
+                     }
+                     catch (Exception ex) when (ex is not OperationCanceledException)
+                     {
+                         _logger.LogWarning(ex, "Probe error for {Name} ({Ip}): {Error}", d.Name, d.Ip, ex.Message);
+                         await UpdateStateAndPublishIfChanged(d, up: false, ct);
+                     }
+                     finally
+                     {
+                         _gate.Release();
+                     }
+                 }, ct));
+             }
+
+             await Task.WhenAll(tasks);
+             _logger.LogDebug("Completed device ping cycle for {Count} devices", devicesToPing.Count);
+             
+             // Publish status snapshot after each ping cycle so the API has a fresh view of device statuses
+             try
+             {
+                 var snapshot = _state.Values.Select(s => new DeviceStatus(s.Id, s.Name, s.Ip, s.IsUp ? "ONLINE" : "OFFLINE", s.ChangedAt, null)).ToArray();
+                 _logger.LogInformation("Publishing status snapshot for {Count} devices after ping cycle", snapshot.Length);
+                 await _publisher.HeartbeatAsync(snapshot, ct);
+             }
+             catch (Exception ex)
+             {
+                 _logger.LogWarning(ex, "Failed to send status snapshot after ping cycle: {Error}", ex.Message);
+             }
         }
     }
 

--- a/src/ProdControlAV.Agent/Services/StatusPublisher.cs
+++ b/src/ProdControlAV.Agent/Services/StatusPublisher.cs
@@ -63,16 +63,34 @@ public sealed class StatusPublisher : IStatusPublisher
             }
             var dto = new
             {
+                // Use agent-style bulk upload format expected by API: { tenantId: guid, readings: [ { deviceId, isOnline, latencyMs, message } ] }
                 TenantId = _api.TenantId,
-                DeviceId = status.Id,
-                Status = status.State,
-                LatencyMs = status.PingMs,
-                ObservedAt = DateTimeOffset.UtcNow
-            };
+                Readings = new[]
+                {
+                    new {
+                        DeviceId = status.Id,
+                        IsOnline = string.Equals(status.State, "ONLINE", StringComparison.OrdinalIgnoreCase),
+                        LatencyMs = status.PingMs,
+                        Message = (string?)null
+                    }
+                }
+             };
+
+            // Log the serialized payload for debugging when API returns 400
+            string payloadJson = JsonSerializer.Serialize(dto, _json);
+            _logger.LogDebug("Status publish payload: {PayloadJson}", payloadJson);
+
             using var req = new HttpRequestMessage(HttpMethod.Post, _api.StatusEndpoint);
             req.Content = JsonContent.Create(dto, options: _json);
             req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             var res = await _http.SendAsync(req, ct);
+
+            if (!res.IsSuccessStatusCode)
+            {
+                var errorBody = await res.Content.ReadAsStringAsync(ct);
+                _logger.LogWarning("Status publish failed: Code={StatusCode} Body={Body}", res.StatusCode, errorBody);
+            }
+
             res.EnsureSuccessStatusCode();
             _logger.LogInformation("State change posted successfully: {Name} {Ip} -> {State}", status.Name, status.Ip, status.State);
         }
@@ -105,6 +123,52 @@ public sealed class StatusPublisher : IStatusPublisher
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to send heartbeat: {Error}", ex.Message);
+        }
+
+        // Also send the status snapshot to the agents status endpoint so the API always receives fresh device statuses
+        if (string.IsNullOrWhiteSpace(_api.StatusEndpoint)) return;
+        try
+        {
+            var token = await _jwtAuth.GetValidTokenAsync(ct);
+            if (string.IsNullOrEmpty(token))
+            {
+                _logger.LogWarning("Failed to obtain valid JWT token for status snapshot publishing");
+                return;
+            }
+
+            var readings = snapshot.Select(s => new {
+                DeviceId = s.Id,
+                IsOnline = string.Equals(s.State, "ONLINE", StringComparison.OrdinalIgnoreCase),
+                LatencyMs = s.PingMs,
+                Message = (string?)null
+            }).ToArray();
+
+            var payload = new {
+                TenantId = _api.TenantId,
+                Readings = readings
+            };
+
+            string payloadJson = JsonSerializer.Serialize(payload, _json);
+            _logger.LogDebug("Status snapshot payload: {PayloadJson}", payloadJson);
+
+            using var req2 = new HttpRequestMessage(HttpMethod.Post, _api.StatusEndpoint);
+            req2.Content = JsonContent.Create(payload, options: _json);
+            req2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            var res2 = await _http.SendAsync(req2, ct);
+            if (!res2.IsSuccessStatusCode)
+            {
+                var errorBody = await res2.Content.ReadAsStringAsync(ct);
+                _logger.LogWarning("Status snapshot publish failed: Code={StatusCode} Body={Body}", res2.StatusCode, errorBody);
+            }
+            else
+            {
+                _logger.LogDebug("Status snapshot published successfully");
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to publish status snapshot: {Error}", ex.Message);
         }
     }
 }

--- a/src/ProdControlAV.WebApp/Controllers/DeviceApiClient.cs
+++ b/src/ProdControlAV.WebApp/Controllers/DeviceApiClient.cs
@@ -13,19 +13,19 @@ public class DeviceApiClient
     public DeviceApiClient(HttpClient http) => _http = http;
 
     public async Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken ct = default) =>
-        await _http.GetFromJsonAsync<IEnumerable<Device>>("api/devices", ct) ?? [];
+        await _http.GetFromJsonAsync<IEnumerable<Device>>("api/devices", ct) ?? Enumerable.Empty<Device>();
     
     public async Task<List<Device>> GetDevices(CancellationToken ct = default)
     {
-        var devices = await _http.GetFromJsonAsync<IEnumerable<Device>>("api/devices", ct);
+        var devices = await _http.GetFromJsonAsync<IEnumerable<Device>>("api/devices/devices", ct);
         return devices?.ToList() ?? new List<Device>();
     }
     
     public async Task<IEnumerable<DeviceAction>> GetDeviceActionsAsync(CancellationToken ct = default) =>
-        await _http.GetFromJsonAsync<IEnumerable<DeviceAction>>("api/devices/actions", ct) ?? [];
+        await _http.GetFromJsonAsync<IEnumerable<DeviceAction>>("api/devices/actions", ct) ?? Enumerable.Empty<DeviceAction>();
 
     public async Task AddNewDeviceAsync(Device device, CancellationToken ct = default) =>
-        await _http.PostAsync("app/devices", JsonContent.Create(device), ct);
+        await _http.PostAsync("api/devices", JsonContent.Create(device), ct);
     
     public async Task UpdateDevice(Device device, CancellationToken ct = default)
     {

--- a/src/ProdControlAV.WebApp/Shared/NavMenu.razor
+++ b/src/ProdControlAV.WebApp/Shared/NavMenu.razor
@@ -122,7 +122,7 @@
         displayName = "Signing out...";
         StateHasChanged();
         await Http.PostAsync("/api/auth/logout", content: null);
-        await JSRuntime.InvokeVoidAsync("window.location.replace", "/login");
+        await JSRuntime.InvokeVoidAsync("window.location.replace", "/");
     }
 
     private class UserInfoResponse


### PR DESCRIPTION
resolved agent issues
- now sending payload to endpoint to update status IF it changes for a given device
- more thorough logging to determine ping cycle and status publish progress

web issues
- signing out either via timeout or clicking sign out now takes you back to the login screen

api 
- added in logging and builds for table stores on initial app run