### PR TITLE
Agent auth - use established pattern

### DIFF
--- a/src/ProdControlAV.Agent/Services/AtemStatePublisher.cs
+++ b/src/ProdControlAV.Agent/Services/AtemStatePublisher.cs
@@ -10,53 +10,34 @@ public sealed class AtemStatePublisher
     private readonly HttpClient _http;
     private readonly ILogger<AtemStatePublisher> _logger;
     private readonly Guid _deviceId;
-    private const string EndpointTemplate = "https://prodcontrol.app/api/atem/{0}/state";
-    private readonly JwtAuthService _jwtAuth; 
+    private const string EndpointTemplate = "api/atem/{0}/state";
 
-    public AtemStatePublisher(HttpClient httpClient, ILogger<AtemStatePublisher> logger, Guid deviceId, JwtAuthService jwtAuth)
+
+    public AtemStatePublisher(HttpClient httpClient, ILogger<AtemStatePublisher> logger, Guid deviceId)
     {
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _deviceId = deviceId;
-        _jwtAuth = jwtAuth;
     }
-
+    
     public async Task PublishAsync(object state, CancellationToken ct = default)
     {
-        if (state is null)
-            return;
+        if (state is null) return;
 
-        var url = string.Format(EndpointTemplate, _deviceId);
-        string? token = null;
+        var relativeUrl = string.Format(EndpointTemplate, _deviceId);
 
-        if (_jwtAuth != null)
-        {
-            try
-            {
-                token = await _jwtAuth.GetValidTokenAsync(ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to get valid JWT token for publishing ATEM state");
-            }
-        }
-        
         try
         {
-            using var req = new HttpRequestMessage(HttpMethod.Post, url)
+            using var req = new HttpRequestMessage(HttpMethod.Post, relativeUrl)
             {
                 Content = JsonContent.Create(state)
             };
 
-            if (!string.IsNullOrEmpty(token))
-            {
-                req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-            }
+            var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
 
-            var resp = await _http.SendAsync(req, ct);
             if (!resp.IsSuccessStatusCode)
             {
-                var body = await resp.Content.ReadAsStringAsync(ct);
+                var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
                 _logger.LogWarning("Failed to publish ATEM state for {DeviceId}. Status: {StatusCode}, Body: {Body}",
                     _deviceId, resp.StatusCode, body);
             }
@@ -67,13 +48,12 @@ public sealed class AtemStatePublisher
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            // normal cancellation on shutdown
             _logger.LogDebug("Publish canceled for {DeviceId}", _deviceId);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception while publishing ATEM state for {DeviceId}", _deviceId);
-            throw;
         }
     }
+
 }

--- a/src/ProdControlAV.Agent/Services/IAtemStatePublisherFactory.cs
+++ b/src/ProdControlAV.Agent/Services/IAtemStatePublisherFactory.cs
@@ -16,7 +16,6 @@ public sealed class AtemStatePublisherFactory : IAtemStatePublisherFactory
 
     public AtemStatePublisher Create(HttpClient http, ILogger<AtemStatePublisher> logger, Guid deviceId)
     {
-        var jwt = _sp.GetService<JwtAuthService>(); // may be null
-        return new AtemStatePublisher(http, logger, deviceId, jwt);
+        return new AtemStatePublisher(http, logger, deviceId);
     }
 }


### PR DESCRIPTION
Using already established pattern for agent auth on API call, not sure why I was trying to get fancy. 